### PR TITLE
Prolific ID form and button workaround for Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,9 +34,9 @@
 					<p>Entscheiden Sie bitte nach Ihrem Gefühl und denken Sie nicht zu lange über Ihre Entscheidung nach. Das Experiment wird ca. 15 Minuten dauern, der Fortschritt wird Ihnen angezeigt.</p>
 					<form>
 						<p>Bevor es los geht, bitte geben Sie hier Ihre Prolific ID ein:</p>
-						<input id="prolificID" type="text" required placeholder="Prolific ID"/>
+						<input id="prolificID" type="text" placeholder="Prolific ID"/>
 						<h3>Vielen Dank!</h3>
-						<button type="submit" id="start-exp-btn">zum Experiment</button>
+						<button type="button" id="start-exp-btn">zum Experiment</button>
 					</form>
 				</article>
 			</div>

--- a/js/views.js
+++ b/js/views.js
@@ -7,11 +7,15 @@ var initIntroductionView = function(sendData) {
 	var rendered = Mustache.render(view.template);
 	$('#main').html(rendered);
 
-	$('form').on('submit', function(e) {
+	$('#start-exp-btn').on('click', function() {
 		var ID = $('#prolificID').val().trim();
 
-		sendData(ID);
-		exp.getNextView();
+		if (ID === "") {
+				alert("Bitte geben Sie eine Prolific-ID ein.");
+		} else {
+				sendData(ID);
+				exp.getNextView();
+		}
 	});
 
 	return view;


### PR DESCRIPTION
First, it seems like Safari cannot deal with submit as a type of button (puzzles me a bit, but $('form').on('submit', ...) does not work. So we can address the button via its id.

Second, html attribute required does not work in Safari either. So the validation logic has to be somewhere else. I put it into the JS, maybe not the most sophisticated way but it works.